### PR TITLE
Eager load application when generate config

### DIFF
--- a/lib/sphinx/integration/tasks.rake
+++ b/lib/sphinx/integration/tasks.rake
@@ -60,11 +60,13 @@ namespace :sphinx do
 
   desc 'Rebuild Sphinx'
   task :rebuild, [:node] => :environment do |_, args|
+    Rails.application.eager_load!
     Sphinx::Integration::Helper.new(args[:node]).rebuild
   end
 
   desc 'Generate configuration files'
   task :conf => ['sphinx:set_indexing_mode', :environment] do
+    Rails.application.eager_load!
     Sphinx::Integration::Helper.new.configure
   end
 


### PR DESCRIPTION
@abak-press/pullviewers 
в рельсах 3.1 3.2 есть проблема, что в rake тасках eager load не вызывается автоматически, соответственно не все модели из гемов загружаются, и если в какой-то определён индекс сфинкса, то он не попадёт в конфиг
