### PR TITLE
fix: sphinx should load all indexes in index process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ spec/internal/config/database.yml
 spec/internal/config/sphinx.yml
 combustion
 .ruby-version
+Makefile.local

--- a/lib/sphinx/integration/helper.rb
+++ b/lib/sphinx/integration/helper.rb
@@ -24,6 +24,8 @@ module Sphinx::Integration
     end
 
     def initialize(node = nil)
+      ThinkingSphinx.context.define_indexes
+
       node = node.presence || 'all'
 
       if config.replication? && !config.remote?

--- a/lib/sphinx/integration/tasks.rake
+++ b/lib/sphinx/integration/tasks.rake
@@ -54,6 +54,8 @@ namespace :sphinx do
 
   desc 'Index Sphinx'
   task :index, [:node, :offline] => :environment do |_, args|
+    Rails.application.eager_load!
+
     is_offline = args[:offline].present? && %w(true yes y da offline).include?(args[:offline])
     Sphinx::Integration::Helper.new(args[:node]).index(!is_offline)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'rubygems'
 require 'bundler'
+require 'pry-debugger'
 
 Bundler.require :default, :development
 

--- a/spec/sphinx/integration/helper_spec.rb
+++ b/spec/sphinx/integration/helper_spec.rb
@@ -36,6 +36,16 @@ describe Sphinx::Integration::Helper do
     )
   end
 
+  describe '#initialize' do
+    let(:spec_options) { {} }
+
+    it 'define indexes after initialize' do
+      helper
+
+      expect(ModelWithRt.sphinx_indexes).not_to be_empty
+    end
+  end
+
   context 'when local' do
     let(:spec_options) { {'remote' => false} }
 

--- a/sphinx-integration.gemspec
+++ b/sphinx-integration.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'combustion'
   gem.add_development_dependency 'mock_redis'
   gem.add_development_dependency 'database_cleaner'
+  gem.add_development_dependency 'pry-debugger'
 end


### PR DESCRIPTION
Fix sphinx index process:
1. If models is located in subdirs (app/models/apress/demands/tender.rb)
   thinking sphinx not load that models. See
   https://github.com/pat/thinking-sphinx/blob/v2/lib/thinking_sphinx/context.rb#L54
2. Model not include index if model define indexes without extensions which call
   define_indexes

Example:

``` ruby

class Tender
  define_index('tender') { ... }
end

Tender.sphinx_indexes #=> []

module TenderSphinxExtension
   included do
     define_indexes

     index = sphinx_indexes.find { |i| i.name == 'blog_post' }
     #...
   end
end

Tender.send(:include, TenderSphinxExtension)
Tender.sphinx_indexes #=> [ThinkingSphinx::Index]
```

And with this bugs helper can`t find rt_indexes for tender
