### PR TITLE
fix: Transmitter.update_fields when full indexing

### DIFF
--- a/lib/sphinx/integration/extensions/thinking_sphinx.rb
+++ b/lib/sphinx/integration/extensions/thinking_sphinx.rb
@@ -12,6 +12,7 @@ module Sphinx::Integration::Extensions::ThinkingSphinx
   autoload :Source, 'sphinx/integration/extensions/thinking_sphinx/source'
   autoload :Configuration, 'sphinx/integration/extensions/thinking_sphinx/configuration'
   autoload :LastIndexingTime, 'sphinx/integration/extensions/thinking_sphinx/last_indexing_time'
+  autoload :Statements, 'sphinx/integration/extensions/thinking_sphinx/statements'
 
   extend ActiveSupport::Concern
 
@@ -19,10 +20,10 @@ module Sphinx::Integration::Extensions::ThinkingSphinx
     DEFAULT_MATCH = :extended2
     include Sphinx::Integration::FastFacet
     include LastIndexingTime
+    extend Sphinx::Integration::Extensions::ThinkingSphinx::Statements
   end
 
   module ClassMethods
-
     def max_matches
       @ts_max_matches ||= ThinkingSphinx::Configuration.instance.configuration.searchd.max_matches || 5000
     end
@@ -31,6 +32,14 @@ module Sphinx::Integration::Extensions::ThinkingSphinx
       context.indexed_models.each do |model|
         model.constantize.reset_indexes
       end
+    end
+
+    def replication?
+      ThinkingSphinx::Configuration.instance.replication?
+    end
+
+    def log(message)
+      ::ActiveSupport::Notifications.instrument("message.thinking_sphinx", message: message)
     end
 
     # Посылает sql запрос в Sphinx
@@ -59,6 +68,5 @@ module Sphinx::Integration::Extensions::ThinkingSphinx
         end
       end
     end
-
   end
 end

--- a/lib/sphinx/integration/extensions/thinking_sphinx/statements.rb
+++ b/lib/sphinx/integration/extensions/thinking_sphinx/statements.rb
@@ -1,0 +1,58 @@
+module Sphinx
+  module Integration
+    module Extensions
+      module ThinkingSphinx
+        module Statements
+          def replace(index_name, data)
+            query = ::Riddle::Query::Insert.new(index_name, data.keys, data.values).replace!.to_sql
+            execute(query, on_slaves: replication?)
+          end
+
+          def update(index_name, data, where)
+            query = ::Sphinx::Integration::Extensions::Riddle::Query::Update.new(index_name, data, where).to_sql
+            execute(query)
+          end
+
+          def delete(index_name, document_id)
+            query = ::Riddle::Query::Delete.new(index_name, document_id).to_sql
+            execute(query)
+          end
+
+          def soft_delete(index_name, document_id)
+            update(index_name, {sphinx_deleted: 1}, {id: document_id})
+          end
+
+          def select(values, index_name, where)
+            query = ::Riddle::Query::Select.
+              new.
+              reset_values.
+              values(values).
+              from(index_name).
+              where(where).
+              to_sql
+            execute(query).to_a
+          end
+
+          def find_in_batches(index_name, where, options = {})
+            bound = select("min(sphinx_internal_id) as min_id, max(sphinx_internal_id) as max_id",
+                                  index_name,
+                                  where).first
+            return unless bound
+
+            min = bound["min_id"].to_i
+            max = bound["max_id"].to_i
+            return if max.zero?
+            batch_size = options.fetch(:batch_size, 1_000)
+
+            while min <= max
+              where[:sphinx_internal_id] = Range.new(min, min + batch_size - 1)
+              ids = select("sphinx_internal_id", index_name, where).map { |row| row["sphinx_internal_id"].to_i }
+              yield ids if ids.any?
+              min += batch_size
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/sphinx/integration/extensions/thinking_sphinx/statements_spec.rb
+++ b/spec/sphinx/integration/extensions/thinking_sphinx/statements_spec.rb
@@ -1,0 +1,69 @@
+require "spec_helper"
+
+describe ThinkingSphinx do
+  describe ".replace" do
+    it do
+      expect(ThinkingSphinx).
+        to receive(:execute).with("REPLACE INTO product (`company_id`) VALUES (1)", on_slaves: false)
+      ThinkingSphinx.replace("product", company_id: 1)
+    end
+  end
+
+  describe ".update" do
+    it do
+      expect(ThinkingSphinx).
+        to receive(:execute).with("UPDATE product SET company_id = 1 WHERE `id` = 1")
+
+      ThinkingSphinx.update("product", {company_id: 1}, id: 1)
+    end
+  end
+
+  describe ".delete" do
+    it do
+      expect(ThinkingSphinx).
+        to receive(:execute).with("DELETE FROM product WHERE id = 1")
+
+      ThinkingSphinx.delete("product", 1)
+    end
+  end
+
+  describe ".soft_delete" do
+    it do
+      expect(ThinkingSphinx).
+        to receive(:execute).with("UPDATE product SET sphinx_deleted = 1 WHERE `id` = 1")
+
+      ThinkingSphinx.soft_delete("product", 1)
+    end
+  end
+
+  describe ".select" do
+    it do
+      expect(ThinkingSphinx).
+        to receive(:execute).with("SELECT company_id FROM product WHERE `id` = 1")
+
+      ThinkingSphinx.select("company_id", "product", id: 1)
+    end
+  end
+
+  describe ".find_in_batches" do
+    it do
+      expect(ThinkingSphinx).to(
+        receive(:execute).
+          with("SELECT min(sphinx_internal_id) as min_id, max(sphinx_internal_id) as max_id " +
+               "FROM product WHERE `company_id` = 1").
+          and_return([{"min_id" => "1", "max_id" => "2"}])
+      )
+
+      expect(ThinkingSphinx).to(
+        receive(:execute).
+          with("SELECT sphinx_internal_id " +
+               "FROM product WHERE `company_id` = 1 AND `sphinx_internal_id` BETWEEN 1 AND 1000").
+          and_return([{"sphinx_internal_id" => "1"}, {"sphinx_internal_id" => "2"}])
+      )
+
+      result = []
+      ThinkingSphinx.find_in_batches("product", company_id: 1) { |ids| result += ids }
+      expect(result).to eq [1, 2]
+    end
+  end
+end

--- a/spec/sphinx/integration/transmitter_spec.rb
+++ b/spec/sphinx/integration/transmitter_spec.rb
@@ -19,16 +19,16 @@ describe Sphinx::Integration::Transmitter do
   describe '#replace' do
     it do
       expect(transmitter).to receive(:transmitted_data).and_return(field: 123)
-      expect(transmitter).to receive(:sphinx_replace).with('model_with_rt_rt0', field: 123)
-      expect(transmitter).to receive(:sphinx_soft_delete)
+      expect(ThinkingSphinx).to receive(:replace).with('model_with_rt_rt0', field: 123)
+      expect(ThinkingSphinx).to receive(:soft_delete)
     end
     after { transmitter.replace(record) }
   end
 
   describe '#delete' do
     it do
-      expect(transmitter).to receive(:sphinx_delete).with('model_with_rt_rt0', 1)
-      expect(transmitter).to receive(:sphinx_soft_delete)
+      expect(ThinkingSphinx).to receive(:delete).with('model_with_rt_rt0', 1)
+      expect(ThinkingSphinx).to receive(:soft_delete)
     end
     after { transmitter.delete(record) }
   end
@@ -41,18 +41,19 @@ describe Sphinx::Integration::Transmitter do
   describe '#update_fields' do
     context 'when full reindex' do
       before { transmitter.stub(:full_reindex? => true) }
+
       it do
-        expect(transmitter).to receive(:sphinx_select).and_return([{'sphinx_internal_id' => 123}])
-        expect(ModelWithRt).to receive(:where).with(:id => [123]).and_return([record])
-        expect(transmitter).to receive(:replace).with(record)
+        expect(ThinkingSphinx).to receive(:find_in_batches).with("model_with_rt", id: 1).and_yield([1])
       end
+
       after { transmitter.update_fields({:field => 123}, {:id => 1}) }
     end
 
     context 'when no full reindex' do
       it do
-        expect(transmitter).to receive(:sphinx_update)
+        expect(ThinkingSphinx).to receive(:update)
       end
+
       after { transmitter.update_fields({:field => 123}, {:id => 1}) }
     end
   end


### PR DESCRIPTION
По умолчанию сфинкс выбирает только 20 записей.
Поэтому Transmitter обновляет не все записи во время полной переиндексации.

https://jira.railsc.ru/browse/PC4-15139

@abak-press/pullviewers 
