### PR TITLE
fix: зависимость от net-ssh < 3.0

### DIFF
--- a/sphinx-integration.gemspec
+++ b/sphinx-integration.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'rye'
   gem.add_runtime_dependency 'riddle', '>= 1.5.8'
   gem.add_runtime_dependency 'thinking-sphinx', '= 2.0.14'
+  gem.add_runtime_dependency 'net-ssh', '< 3.0'  # начиная с 3.0 нужен ruby 2.0 (тянется rye)
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'bundler'


### PR DESCRIPTION
net-ssh 3.0 тянется rye и требует ruby 2.0
