### PR TITLE
feature: suspend and resume working nodes

### DIFF
--- a/lib/sphinx/integration.rb
+++ b/lib/sphinx/integration.rb
@@ -10,6 +10,7 @@ module Sphinx
     autoload :WasteRecords, 'sphinx/integration/waste_records'
     autoload :ServerPool, 'sphinx/integration/server_pool'
     autoload :Server, 'sphinx/integration/server'
+    autoload :ServerStatus, 'sphinx/integration/server_status'
   end
 end
 

--- a/lib/sphinx/integration/decaying.rb
+++ b/lib/sphinx/integration/decaying.rb
@@ -2,6 +2,8 @@ module Sphinx
   module Integration
     # A float value which decays exponentially toward 0 over time.
     class Decaying
+      MAX_ERROR_RATE = 0.1
+
       attr_accessor :e
       attr_accessor :p
 
@@ -30,6 +32,10 @@ module Sphinx
         dt = now - @t0
         @t0 = now
         @p *= @e**(@r * dt)
+      end
+
+      def satisfy?
+        value < MAX_ERROR_RATE
       end
     end
   end

--- a/lib/sphinx/integration/extensions/riddle/client.rb
+++ b/lib/sphinx/integration/extensions/riddle/client.rb
@@ -19,8 +19,8 @@ module Sphinx
               @server_pool
             end
 
-            def init_server_pool(servers, host)
-              @server_pool = ::Sphinx::Integration::ServerPool.new(servers, host, mysql: false)
+            def init_server_pool(servers, port)
+              @server_pool = ::Sphinx::Integration::ServerPool.new(servers, port, mysql: false)
             end
           end
 

--- a/lib/sphinx/integration/helper.rb
+++ b/lib/sphinx/integration/helper.rb
@@ -15,7 +15,10 @@ module Sphinx::Integration
     delegate :recent_rt, to: 'self.class'
     delegate :log, to: 'ThinkingSphinx'
 
-    [:running?, :stop, :start, :remove_indexes, :remove_binlog, :copy_config, :reload].each do |method_name|
+    [
+      :running?, :stop, :start, :suspend, :resume, :restart,
+      :remove_indexes, :remove_binlog, :copy_config, :reload
+    ].each do |method_name|
       class_eval <<-EORUBY, __FILE__, __LINE__ + 1
         def #{method_name}
           log "#{method_name.capitalize}" do
@@ -42,11 +45,6 @@ module Sphinx::Integration
       end
 
       @sphinx = config.remote? ? HelperAdapters::Remote.new(options) : HelperAdapters::Local.new(options)
-    end
-
-    def restart
-      stop
-      start
     end
 
     def configure

--- a/lib/sphinx/integration/helper_adapters/local.rb
+++ b/lib/sphinx/integration/helper_adapters/local.rb
@@ -16,6 +16,19 @@ module Sphinx
           searchd
         end
 
+        def suspend
+          # no-op
+        end
+
+        def resume
+          # no-op
+        end
+
+        def restart
+          stop
+          start
+        end
+
         def remove_indexes
           remove_files("#{config.searchd_file_path}/*_{core,rt0,rt1}.*")
         end

--- a/lib/sphinx/integration/helper_adapters/remote.rb
+++ b/lib/sphinx/integration/helper_adapters/remote.rb
@@ -83,6 +83,23 @@ module Sphinx
           @ssh.execute("searchd", "--config #{config.config_file}")
         end
 
+        def suspend
+          set_servers_availability(false)
+        end
+
+        def resume
+          set_servers_availability(true)
+        end
+
+        def restart
+          suspend
+          # Wait for all request to be complete
+          sleep(3)
+          stop
+          start
+          resume
+        end
+
         def remove_indexes
           remove_files("#{config.searchd_file_path}/*.*")
         end
@@ -144,6 +161,13 @@ module Sphinx
 
         def reindex_host
           @reindex_host ||= hosts.first
+        end
+
+        def set_servers_availability(value)
+          hosts.each do |host|
+            config.client.class.server_pool.find_server(host).server_status.available = value
+            config.mysql_client.server_pool.find_server(host).server_status.available = value
+          end
         end
       end
     end

--- a/lib/sphinx/integration/mysql/client.rb
+++ b/lib/sphinx/integration/mysql/client.rb
@@ -2,6 +2,8 @@ module Sphinx
   module Integration
     module Mysql
       class Client
+        attr_reader :server_pool
+
         def initialize(hosts, port)
           @server_pool = ServerPool.new(hosts, port)
         end

--- a/lib/sphinx/integration/server_status.rb
+++ b/lib/sphinx/integration/server_status.rb
@@ -1,0 +1,36 @@
+require "request_store"
+
+module Sphinx
+  module Integration
+    class ServerStatus
+      AVAILABLE_FIELD = "available".freeze
+
+      delegate :redis, to: "self.class"
+
+      def initialize(host)
+        @host = host
+      end
+
+      def available?
+        RequestStore.fetch(availability_cache_key) do
+          !(redis.hget(@host, AVAILABLE_FIELD) || 1).to_i.zero?
+        end
+      end
+
+      def available=(value)
+        RequestStore.delete(availability_cache_key)
+        redis.hset(@host, AVAILABLE_FIELD, value ? 1 : 0)
+      end
+
+      private
+
+      def availability_cache_key
+        @availability_cache_key ||= "sphinx_server_availability/#{@host}"
+      end
+
+      def self.redis
+        @redis ||= Redis::Namespace.new("sphinx/integration/server_status", redis: Redis.current)
+      end
+    end
+  end
+end

--- a/lib/sphinx/integration/tasks.rake
+++ b/lib/sphinx/integration/tasks.rake
@@ -46,6 +46,16 @@ namespace :sphinx do
     Sphinx::Integration::Helper.new(args).stop
   end
 
+  desc 'Suspend Sphinx'
+  task :suspend, [:host] => :environment do |_, args|
+    Sphinx::Integration::Helper.new(args).suspend
+  end
+
+  desc 'Resume Sphinx'
+  task :resume, [:host] => :environment do |_, args|
+    Sphinx::Integration::Helper.new(args).resume
+  end
+
   desc 'Restart Sphinx'
   task :restart, [:host] => :environment do |_, args|
     Sphinx::Integration::Helper.new(args).restart

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,12 +21,14 @@ Redis.current = MockRedis.new
 Redis::Classy.db = Redis.current
 
 require "support/helpers/sphinx_conf"
+require "request_store"
 
 RSpec.configure do |config|
   include SphinxConf
 
   config.before(:each) do
     Redis.current.flushdb
+    RequestStore.clear!
     ThinkingSphinx::Configuration.instance.reset
   end
 end

--- a/spec/sphinx/integration/helper_adapters/remote_spec.rb
+++ b/spec/sphinx/integration/helper_adapters/remote_spec.rb
@@ -30,6 +30,22 @@ describe Sphinx::Integration::HelperAdapters::Remote do
     end
   end
 
+  describe "#suspend" do
+    it do
+      adapter.suspend
+      server_status = Sphinx::Integration::ServerStatus.new(ThinkingSphinx::Configuration.instance.address)
+      expect(server_status.available?).to be false
+    end
+  end
+
+  describe "#resume" do
+    it do
+      adapter.resume
+      server_status = Sphinx::Integration::ServerStatus.new(ThinkingSphinx::Configuration.instance.address)
+      expect(server_status.available?).to be true
+    end
+  end
+
   describe "#remove_indexes" do
     it do
       expect(adapter).to receive(:remove_files).with(%r{db/sphinx/test})

--- a/spec/sphinx/integration/helper_spec.rb
+++ b/spec/sphinx/integration/helper_spec.rb
@@ -11,14 +11,6 @@ describe Sphinx::Integration::Helper do
     class_double("Sphinx::Integration::HelperAdapters::Local", new: adapter).as_stubbed_const
   end
 
-  describe "#restart" do
-    it do
-      expect(helper).to receive(:stop)
-      expect(helper).to receive(:start)
-      helper.restart
-    end
-  end
-
   describe "#configure" do
     it do
       expect(ThinkingSphinx::Configuration.instance).to receive(:build).with(/test\.sphinx\.conf/)

--- a/spec/sphinx/integration/server_status_spec.rb
+++ b/spec/sphinx/integration/server_status_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+describe Sphinx::Integration::ServerStatus do
+  let(:server_status) { described_class.new("127.0.0.1") }
+
+  describe "#available?" do
+    it "by default is true" do
+      expect(server_status.available?).to be true
+    end
+  end
+
+  describe "#available=" do
+    it "set right value" do
+      server_status.available = false
+      expect(server_status.available?).to be false
+    end
+
+    it "switch values and clear cache" do
+      server_status.available = false
+      expect(server_status.available?).to be false
+      server_status.available = true
+      expect(server_status.available?).to be true
+    end
+  end
+end

--- a/sphinx-integration.gemspec
+++ b/sphinx-integration.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'riddle', '>= 1.5.8'
   gem.add_runtime_dependency 'thinking-sphinx', '= 2.0.14'
   gem.add_runtime_dependency 'net-ssh', '< 3.0'  # начиная с 3.0 нужен ruby 2.0 (тянется rye)
+  gem.add_runtime_dependency 'request_store', '>= 1.0.8'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'bundler'


### PR DESCRIPTION
https://jira.railsc.ru/browse/PC4-16187

Добавлена возможность приостанавливать запросы на одну из работающих нод.
Во-первых это нужно для рестарта одной из нод, чтобы запросы не слались, когда нода находится в режиме stopwait, потому что коннекты до такой ноды начинают зависать.
Во-вторых это будет полезно, когда надо провести работы на одной из нод, не меняя конфиг приложения, т.е. когда требуется чтобы нода была запущена и запросы на нее не слались.

Гем request_store нужен, чтобы не делать на каждое чтение из сфинкса запрос в редис. Кеш сбрасывается автоматически при обработке следующего запроса приложением.
