### PR TITLE
fix: change min request_store version to 1.2.1

### DIFF
--- a/sphinx-integration.gemspec
+++ b/sphinx-integration.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'riddle', '>= 1.5.8'
   gem.add_runtime_dependency 'thinking-sphinx', '= 2.0.14'
   gem.add_runtime_dependency 'net-ssh', '< 3.0'  # начиная с 3.0 нужен ruby 2.0 (тянется rye)
-  gem.add_runtime_dependency 'request_store', '>= 1.0.8'
+  gem.add_runtime_dependency 'request_store', '>= 1.2.1'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'bundler'


### PR DESCRIPTION
:fire: 
накосячил всё-таки с минимальной версией
мне нужен RequestStore.delete, которого нет в 1.0.8

в проекте обновлю draper до с 1.3.1 до 1.4.0 - там единственное изменение - это как раз они ослабили зависимость от resquest_store
