### PR TITLE
fix: allow to use stanalone rspec-rails

### DIFF
--- a/lib/sphinx/integration/railtie.rb
+++ b/lib/sphinx/integration/railtie.rb
@@ -40,9 +40,8 @@ module Sphinx::Integration
     end
 
     initializer 'sphinx_integration.rspec' do
-      if defined?(::RSpec)
-        require 'rspec/version'
-        if Gem::Version.new(RSpec::Version::STRING) >= Gem::Version.new('3.0.0')
+      if defined?(::RSpec::Core)
+        if Gem::Version.new(RSpec::Core::Version::STRING) >= Gem::Version.new('3.0.0')
           RSpec.configure do |c|
             c.before(:each) do |example|
               unless example.metadata.fetch(:with_sphinx, false)


### PR DESCRIPTION
Проблема: Если подлючен только rspec-rails то тут падает с ошибкой

```
bundler: failed to load command: rspec (/usr/local/gems/bin/rspec)
LoadError: cannot load such file -- rspec/version
```

Как работало раньше:
Обычно подключают 2 гема rspec и rspec-rails
Но это не совсем правильно так как достаточно одного rspec-rails
