### PR TITLE
fix: :table_name key may be missing

### DIFF
--- a/lib/sphinx/integration/extensions/thinking_sphinx/source/sql.rb
+++ b/lib/sphinx/integration/extensions/thinking_sphinx/source/sql.rb
@@ -63,7 +63,7 @@ module Sphinx::Integration::Extensions::ThinkingSphinx::Source::SQL
         join_table = if (query = join_options[:query])
                        "(#{query})"
                      else
-                       join_options.fetch(:table_name)
+                       join_options.fetch(:table_name, join_alias)
                      end
         join_on = join_options.fetch(:on)
         join_type = join_options[:type].to_s.upcase

--- a/spec/sphinx/integration/extensions/thinking_sphinx/source/sql_spec.rb
+++ b/spec/sphinx/integration/extensions/thinking_sphinx/source/sql_spec.rb
@@ -45,11 +45,16 @@ describe ThinkingSphinx::Source::SQL do
             :type => :left,
             :table_name => :rubrics,
             :on => 'model_with_disks.rubric_id = rubrics_alias.id'
+          },
+          :products => {
+            :type => :left,
+            :on => 'model_with_disks.products_id = products.id'
           }
         }
       end
       expected_sql = 'LEFT JOIN rubrics AS rubrics ON model_with_disks.rubric_id = rubrics.id ' \
-                     'LEFT JOIN rubrics AS rubrics_alias ON model_with_disks.rubric_id = rubrics_alias.id'
+                     'LEFT JOIN rubrics AS rubrics_alias ON model_with_disks.rubric_id = rubrics_alias.id ' \
+                     'LEFT JOIN products AS products ON model_with_disks.products_id = products.id'
       index.sources.first.to_sql(:offset => 0).should include(expected_sql)
     end
 


### PR DESCRIPTION
https://jira.railsc.ru/browse/GOODS-696

[Комментарий из прошлого реквеста](https://github.com/abak-press/sphinx-integration/pull/100/files/8eff58348ee7d69e7eb365eb44ea0c76eadf638f#diff-3fad922249bf28abfb42289b2b2a8e6d)

и всё-таки table_name может отсутствовать, потому что в некоторых местах [джойны не через билдер задаются](https://github.com/abak-press/apress-products-sphinx/blob/master/app/models/apress/products/sphinx/extensions/product.rb#L121-L127); мой косяк, что я не перепроверил сразу :disappointed: 