### PR TITLE
fix: respect :as key in options

### DIFF
--- a/lib/sphinx/integration/extensions/thinking_sphinx/source/sql.rb
+++ b/lib/sphinx/integration/extensions/thinking_sphinx/source/sql.rb
@@ -68,7 +68,7 @@ module Sphinx::Integration::Extensions::ThinkingSphinx::Source::SQL
         join_on = join_options.fetch(:on)
         join_type = join_options[:type].to_s.upcase
 
-        join_sql << "#{join_type} JOIN #{join_table} AS #{join_alias} ON #{join_on}"
+        join_sql << "#{join_type} JOIN #{join_table} AS #{join_options.fetch(:as, join_alias)} ON #{join_on}"
       end
 
       unless join_sql.empty?

--- a/spec/sphinx/integration/extensions/thinking_sphinx/source/sql_spec.rb
+++ b/spec/sphinx/integration/extensions/thinking_sphinx/source/sql_spec.rb
@@ -49,12 +49,18 @@ describe ThinkingSphinx::Source::SQL do
           :products => {
             :type => :left,
             :on => 'model_with_disks.products_id = products.id'
+          },
+          'public.traits' => {
+            :type => :left,
+            :on => 'model_with_disks.traits_id = traits_alias.id',
+            :as => 'traits_alias'
           }
         }
       end
       expected_sql = 'LEFT JOIN rubrics AS rubrics ON model_with_disks.rubric_id = rubrics.id ' \
                      'LEFT JOIN rubrics AS rubrics_alias ON model_with_disks.rubric_id = rubrics_alias.id ' \
-                     'LEFT JOIN products AS products ON model_with_disks.products_id = products.id'
+                     'LEFT JOIN products AS products ON model_with_disks.products_id = products.id ' \
+                     'LEFT JOIN public.traits AS traits_alias ON model_with_disks.traits_id = traits_alias.id'
       index.sources.first.to_sql(:offset => 0).should include(expected_sql)
     end
 


### PR DESCRIPTION
https://jira.railsc.ru/browse/GOODS-696

Сгенерился sql вида ```INNER JOIN deals.offer_moderations AS deals.offer_moderations```, на точке ломается