### PR TITLE
fix: disable notification about failed stop in stage

### DIFF
--- a/lib/sphinx/integration.rb
+++ b/lib/sphinx/integration.rb
@@ -6,6 +6,10 @@ require 'redis-mutex'
 
 module Sphinx
   module Integration
+    extend SingleForwardable
+
+    def_delegators 'Rails.application.config.sphinx_integration', :[], :[]=, :fetch
+
     autoload :Helper, 'sphinx/integration/helper'
     autoload :Mysql, 'sphinx/integration/mysql'
     autoload :Searchd, 'sphinx/integration/searchd'

--- a/lib/sphinx/integration/helper.rb
+++ b/lib/sphinx/integration/helper.rb
@@ -80,7 +80,8 @@ module Sphinx::Integration
     def rebuild
       log "Rebuild sphinx"
 
-      stop rescue nil
+      stop unless Sphinx::Integration.fetch(:rebuild, {})[:pass_sphinx_stop]
+
       clean
       configure
       copy_config

--- a/lib/sphinx/integration/railtie.rb
+++ b/lib/sphinx/integration/railtie.rb
@@ -38,7 +38,7 @@ module Sphinx::Integration
       end
     end
 
-    initializer "sphinx-integration.common", before: :load_config_initializers do
+    initializer "sphinx-integration.common", before: :load_config_initializers do |app|
       ::Sphinx::Integration::Container.namespace("logger") do
         register "stdout", -> do
           logger = ::Logger.new(STDOUT)
@@ -66,6 +66,8 @@ module Sphinx::Integration
           client.create_message("sadness", "#{message} on #{`hostname`}", hashtags: ["#sphinx"]) if client.config.token
         end
       end
+
+      app.config.sphinx_integration = {rebuild: {pass_sphinx_stop: false}}
     end
 
     initializer 'sphinx_integration.rspec' do

--- a/lib/sphinx/integration/version.rb
+++ b/lib/sphinx/integration/version.rb
@@ -1,5 +1,5 @@
 module Sphinx
   module Integration
-    VERSION = '7.1.0'.freeze
+    VERSION = '7.1.1'.freeze
   end
 end


### PR DESCRIPTION
В ноже изначально сфинкс не запущен и при каждом деплое в чат сыплятся уведомления о том, что остановить незапущенный сфинкс не удалось.