### PR TITLE
fix: dont reuse connection

### DIFF
--- a/lib/sphinx/integration/transmitter.rb
+++ b/lib/sphinx/integration/transmitter.rb
@@ -212,7 +212,7 @@ module Sphinx::Integration
     #
 
     def connection
-      @connection ||= klass.connection
+      klass.connection
     end
 
     def sphinx_document_ids(records)


### PR DESCRIPTION
Нельзя просто так взять и "закешировать" коннекцию
![image](https://user-images.githubusercontent.com/751651/47430820-da83f900-d7b3-11e8-958b-43c2d20c80de.png)
