### PR TITLE
fix: do not merge ids into huge list of soft delete log

### DIFF
--- a/lib/sphinx/integration/version.rb
+++ b/lib/sphinx/integration/version.rb
@@ -1,5 +1,5 @@
 module Sphinx
   module Integration
-    VERSION = '7.3.1'.freeze
+    VERSION = '7.3.2'.freeze
   end
 end


### PR DESCRIPTION
Проблема возникла после применения пачечного реплейса.
Сейчас в query log начали записываться целыми пачками идшники, которые следует "удалить" из сфинкса.
Во время `#replay_soft_delete_log` происходит вытаскивание событий из query log'а по 5К, каждое "событие" содержит `index_name` и набор `ids`: их сейчас до 500. Далее происходит мерж `ids` по `index_name`, в итоге получаем гигантский список идшников, из которого формируется один запрос `UPDATE product_core SET sphinx_delted = 1 WHERE id IN ( <около 50К идшников> )`.

В данном коммите я разбиваю запрос на "удаление" по пачкам в 500 идшников.
