### PR TITLE
fix: do not modify transmitted records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,12 @@ if RUBY_VERSION < '2.4'
   gem 'mock_redis', '< 0.20', require: false
   gem 'redis-namespace', '< 1.7.0', require: false
   gem 'simplecov-html', '< 0.11.0', require: false
+  gem 'byebug', '< 11.1.0', require: false
 end
 
 if RUBY_VERSION < '2.5'
   gem 'sprockets', '< 4.0.0', require: false
 end
+
+gem 'pry', '< 0.13.0', require: false
+gem 'rspec-rails', '< 4.0.0', require: false

--- a/lib/sphinx/integration/transmitter.rb
+++ b/lib/sphinx/integration/transmitter.rb
@@ -241,7 +241,7 @@ module Sphinx::Integration
       sphinx_offset = klass.sphinx_offset
       indexed_models_size = ::ThinkingSphinx.context.indexed_models.size
 
-      records.map! do |item|
+      records.map do |item|
         if item.respond_to?(:sphinx_document_id)
           item.sphinx_document_id
         else

--- a/lib/sphinx/integration/version.rb
+++ b/lib/sphinx/integration/version.rb
@@ -1,5 +1,5 @@
 module Sphinx
   module Integration
-    VERSION = '7.8.0'.freeze
+    VERSION = '7.8.1'.freeze
   end
 end

--- a/spec/sphinx/integration/transmitter_spec.rb
+++ b/spec/sphinx/integration/transmitter_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Sphinx::Integration::Transmitter do
   let(:record) { mock_model ModelWithRt }
+  let(:records) { [record] }
   let(:transmitter) { described_class.new(record.class) }
   let(:client) { ::ThinkingSphinx::Configuration.instance.mysql_client }
   let(:plain_index) { record.class.sphinx_indexes.find(&:rt?).plain }
@@ -32,8 +33,8 @@ describe Sphinx::Integration::Transmitter do
         expect(client).to receive(:write).
           with("UPDATE model_with_rt_core SET sphinx_deleted = 1 WHERE " \
                "`id` IN (#{record.sphinx_document_id}) AND `sphinx_deleted` = 0")
-
-        transmitter.replace(record)
+        transmitter.replace(records)
+        expect(records.first).to eq record
       end
 
       context 'when indexing' do


### PR DESCRIPTION
В частности это ломает уникальные джобы трансмиттера (лок в редисе остаётся после завершения, потому что меняются аргументы джоба):

```
** [12:15:16 2020-04-08] 1181: got: (Job{sphinx} | Sphinx::Integration::TransmitterJob | ["2a7011921cb98c5277ba45aeea94cd686046eed7", "Apress::Products::Product", "replace", [85629696]])
** [12:15:17 2020-04-08] 37715: done: (Job{sphinx} | Sphinx::Integration::TransmitterJob | ["2a7011921cb98c5277ba45aeea94cd686046eed7", "Apress::Products::Product", "replace", [685037570]])

```