### PR TITLE
feature: allow to configure _vip connections

### DIFF
--- a/lib/sphinx/integration/extensions/riddle.rb
+++ b/lib/sphinx/integration/extensions/riddle.rb
@@ -3,5 +3,6 @@ module Sphinx::Integration::Extensions
   module Riddle
     autoload :Query, 'sphinx/integration/extensions/riddle/query'
     autoload :Client, 'sphinx/integration/extensions/riddle/client'
+    autoload :Configuration, 'sphinx/integration/extensions/riddle/configuration'
   end
 end

--- a/lib/sphinx/integration/extensions/riddle/configuration.rb
+++ b/lib/sphinx/integration/extensions/riddle/configuration.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Sphinx
+  module Integration
+    module Extensions
+      module Riddle
+        module Configuration
+          autoload :Searchd, 'sphinx/integration/extensions/riddle/configuration/searchd'
+        end
+      end
+    end
+  end
+end

--- a/lib/sphinx/integration/extensions/riddle/configuration/searchd.rb
+++ b/lib/sphinx/integration/extensions/riddle/configuration/searchd.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module Sphinx
+  module Integration
+    module Extensions
+      module Riddle
+        module Configuration
+          module Searchd
+            extend ActiveSupport::Concern
+
+            included do
+              # Специальный порт для служебных задач мониторинга
+              #
+              # Все запросы, отправленные через данный порт,
+              # исполняются в обход очереди thread pool, и исполняются сразу (в случае если `workers=thread_pool`).
+              # То есть они не учитываются в лимите назначенном через настройку `queue_max_length`
+              #
+              # Пруфы (на момент коммита у нас была версия 3.0.2):
+              #   https://github.com/manticoresoftware/manticoresearch/blob/01dd0122f4c51a0a7e1056f5543106d8abd73c4f/src/searchd.cpp#L22757
+              #   https://github.com/manticoresoftware/manticoresearch/blob/01dd0122f4c51a0a7e1056f5543106d8abd73c4f/src/searchd.cpp#L22764
+              #
+              # Документация: https://docs.manticoresearch.com/3.0.2/singlehtml/index.html#listen
+              attr_accessor :mysql41_vip
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/sphinx/integration/extensions/thinking_sphinx/configuration.rb
+++ b/lib/sphinx/integration/extensions/thinking_sphinx/configuration.rb
@@ -100,9 +100,11 @@ module Sphinx::Integration::Extensions::ThinkingSphinx::Configuration
     # добавлено выставление опции listen по на нашим правилам
     listen_ip = "0.0.0.0"
     mysql_port = @configuration.searchd.mysql41.is_a?(TrueClass) ? "9306" : @configuration.searchd.mysql41
+    mysql_port_vip = @configuration.searchd.mysql41_vip.presence || "9307"
     @configuration.searchd.listen = [
       "#{listen_ip}:#{@configuration.searchd.port}",
-      "#{listen_ip}:#{mysql_port}:mysql41"
+      "#{listen_ip}:#{mysql_port}:mysql41",
+      "#{listen_ip}:#{mysql_port_vip}:mysql41_vip"
     ]
   end
 

--- a/lib/sphinx/integration/railtie.rb
+++ b/lib/sphinx/integration/railtie.rb
@@ -7,6 +7,8 @@ module Sphinx::Integration
   class Railtie < Rails::Railtie
     initializer 'sphinx_integration.configuration', before: 'thinking_sphinx.sphinx' do
       ThinkingSphinx::Configuration.include Sphinx::Integration::Extensions::ThinkingSphinx::Configuration
+      Riddle::Configuration::Searchd.include Sphinx::Integration::Extensions::Riddle::Configuration::Searchd
+
       ThinkingSphinx.database_adapter = :postgresql
 
       ThinkingSphinx::AutoVersion.include Sphinx::Integration::Extensions::ThinkingSphinx::AutoVersion
@@ -28,7 +30,7 @@ module Sphinx::Integration
         ThinkingSphinx::Index,
         ThinkingSphinx::PostgreSQLAdapter
       ].each do |klass|
-        klass.send :include, "Sphinx::Integration::Extensions::#{klass.name}".constantize
+        klass.include "Sphinx::Integration::Extensions::#{klass.name}".constantize
       end
 
       ActiveSupport.on_load :active_record do


### PR DESCRIPTION
https://jira.railsc.ru/browse/BPC-18802

_vip -- это специальный адрес для служебных задач мониторинга
Все запросы, отправленные через данный порт, исполняются в обход очереди thread pool, и исполняются сразу (в случае если `workers=thread_pool`). То есть они не учитываются в лимите назначенном через настройку `queue_max_length`

Пруфы (на момент коммита у нас была версия 3.0.2):
https://github.com/manticoresoftware/manticoresearch/blob/01dd0122f4c51a0a7e1056f5543106d8abd73c4f/src/searchd.cpp#L22757
https://github.com/manticoresoftware/manticoresearch/blob/01dd0122f4c51a0a7e1056f5543106d8abd73c4f/src/searchd.cpp#L22764