### PR TITLE
fix: query to another server if sphinx responded with retry error

### DIFF
--- a/lib/sphinx/integration/searchd/connection_pool.rb
+++ b/lib/sphinx/integration/searchd/connection_pool.rb
@@ -5,7 +5,7 @@ module Sphinx
   module Integration
     module Searchd
       class ConnectionPool
-        MAXIMUM_RETRIES = 3
+        MAXIMUM_RETRIES = 2
 
         def initialize(server)
           @server = server


### PR DESCRIPTION
https://jira.railsc.ru/browse/BPC-18802

- sphinx может ответить со статусом retry, у нас этот статус обрабатывался как "паника" и приложение завершало работу, но  на самом деле, этот статус говорит о том, что нужно повторить запрос (ваш КЭП)
- уменьшил кол-во попыток выполнить запрос на одном хосте сфинкса, чтобы не задудосить его, по исчерпании попыток для одного сервера запрос после ошибки "retry" направляется на другую ноду, тем самым обеспечивается более-менее балансировка нагрузки. Хотя нужно еще доработать чтение ответа из сокета, добавить таймаут и в случае исчерпания таймаута перекидывать запрос на другую ноду. Добавлю эту фичу позднее.