### PR TITLE
feature: allow to use old fationed method for read from sock

### DIFF
--- a/lib/sphinx/integration/extensions/riddle/client.rb
+++ b/lib/sphinx/integration/extensions/riddle/client.rb
@@ -44,7 +44,6 @@ module Sphinx
             version  = 0
             length   = 0
             message  = ::Riddle.encode(Array(messages).join(''), 'ASCII-8BIT')
-            read_timeout = Integer(::Sphinx::Integration.fetch(:socket_read_timeout_sec))
 
             connect do |socket|
               case command
@@ -62,8 +61,13 @@ module Sphinx
                 socket.send request_header(command, message.length) + message, 0
               end
 
+              # Receive header
               header = ''.dup
-              read_with_timeout!(socket, HEADER_LENGTH, header, read_timeout)
+              if read_timeout.nil?
+                header = socket.recv(HEADER_LENGTH)
+              else
+                nonblock_read!(socket, HEADER_LENGTH, header, read_timeout)
+              end
               status, version, length = header.unpack('n2N')
 
               # Если вернулся ответ Retry, то нужно попробовать
@@ -73,7 +77,12 @@ module Sphinx
                 raise ::Riddle::ResponseError, 'Searchd responded with retry error'
               end
 
-              read_with_timeout!(socket, length, response, read_timeout)
+              # Receive body
+              if read_timeout.nil?
+                block_read(socket, length, response)
+              else
+                nonblock_read!(socket, length, response, read_timeout)
+              end
 
               if response.empty? || response.bytesize != length
                 raise ::Riddle::ResponseError, "No response from searchd (status: #{status}, version: #{version})"
@@ -101,14 +110,32 @@ module Sphinx
             end
           end
 
+          def read_timeout
+            return @read_timeout if defined?(@read_timeout)
+
+            cfg_timeout = ::Sphinx::Integration[:socket_read_timeout_sec]
+            @read_timeout = cfg_timeout && Integer(cfg_timeout)
+          end
+
+          def block_read(socket, maxlength, response)
+            while response.length < (maxlength || 0)
+              part = socket.recv(maxlength - response.length)
+
+              # will return 0 bytes if remote side closed TCP connection, e.g, searchd segfaulted.
+              break if part.length == 0 && socket.is_a?(TCPSocket)
+
+              response << part if part
+            end
+          end
+
           # Private: читает из sock maxlength байт в outbuf используя read(2) syscall и select(2)
           # после выставления флага на сокет O_NONBLOCK, с таймаутом timeout секунд
-          def read_with_timeout!(sock, maxlength, outbuf, timeout)
+          def nonblock_read!(sock, maxlength, outbuf, timeout)
             raise ::Riddle::ResponseError, 'Timeout reading from socket' if timeout == 0
 
             sock_ready = IO.select(_read_fds = [sock], _write_fds = [], _exception_fds = [], 1)
             # Timeout
-            return read_with_timeout!(sock, maxlength, outbuf, timeout-1) if sock_ready.nil?
+            return nonblock_read!(sock, maxlength, outbuf, timeout - 1) if sock_ready.nil?
 
             begin
               outbuf << sock.read_nonblock(maxlength)
@@ -118,7 +145,7 @@ module Sphinx
             # Read it all?
             return outbuf if maxlength == outbuf.bytesize
 
-            read_with_timeout!(sock, maxlength, outbuf, timeout-1)
+            nonblock_read!(sock, maxlength, outbuf, timeout - 1)
           end
         end
       end

--- a/lib/sphinx/integration/extensions/riddle/client.rb
+++ b/lib/sphinx/integration/extensions/riddle/client.rb
@@ -4,7 +4,6 @@ module Sphinx
     module Extensions
       module Riddle
         module Client
-          MAXIMUM_RETRIES = 2
           HEADER_LENGTH = 8
 
           extend ActiveSupport::Concern

--- a/lib/sphinx/integration/railtie.rb
+++ b/lib/sphinx/integration/railtie.rb
@@ -40,7 +40,7 @@ module Sphinx::Integration
 
     initializer "sphinx-integration.common", before: :load_config_initializers do |app|
       app.config.sphinx_integration = {
-        socket_read_timeout_sec: 5,
+        socket_read_timeout_sec: nil, # not constrained by default
         rebuild: {pass_sphinx_stop: false},
         # Custom DI container
         di: {

--- a/lib/sphinx/integration/server_pool.rb
+++ b/lib/sphinx/integration/server_pool.rb
@@ -20,12 +20,14 @@ module Sphinx
 
           if skip_servers.size >= @servers.size
             ::ThinkingSphinx.fatal("Error on servers: #{skip_servers.map(&:to_s).join(', ')}")
-            ::ThinkingSphinx.fatal("#{e.message}\n#{e.backtrace.join("\n")}")
+            ::ThinkingSphinx.debug("#{e.message}\n#{e.backtrace.join("\n")}")
             raise
           else
+            server_was = server
             server = choose(skip_servers)
-            ::ThinkingSphinx.info("Retrying with next server #{server}")
-            ::ThinkingSphinx.info("#{e.message}\n#{e.backtrace.join("\n")}")
+            ::ThinkingSphinx.error("#{server_was}: #{e.message}")
+            ::ThinkingSphinx.info("Retrying with next server #{server}, was #{server_was}")
+            ::ThinkingSphinx.debug(e.backtrace.join("\n"))
             retry
           end
         end
@@ -43,11 +45,11 @@ module Sphinx
 
             if skip_servers.size >= servers.size
               ::ThinkingSphinx.fatal("Error on servers: #{skip_servers.map(&:to_s).join(', ')}")
-              ::ThinkingSphinx.fatal("#{e.message}\n#{e.backtrace.join("\n")}")
+              ::ThinkingSphinx.debug("#{e.message}\n#{e.backtrace.join("\n")}")
               raise
             else
               ::ThinkingSphinx.info("Error on server #{server}")
-              ::ThinkingSphinx.info("#{e.message}\n#{e.backtrace.join("\n")}")
+              ::ThinkingSphinx.debug(e.backtrace.join("\n"))
             end
           end
         end
@@ -56,11 +58,11 @@ module Sphinx
       private
 
       def choose(skip_servers)
-        if skip_servers.any?
-          servers =  @servers.select { |server| !skip_servers.include?(server) }
-        else
-          servers = @servers
-        end
+        servers = if skip_servers.empty?
+                    @servers
+                  else
+                    @servers.select { |server| !skip_servers.include?(server) }
+                  end
 
         best_servers = servers.select(&:fine?)
 

--- a/lib/sphinx/integration/server_pool.rb
+++ b/lib/sphinx/integration/server_pool.rb
@@ -49,7 +49,7 @@ module Sphinx
               raise
             else
               ::ThinkingSphinx.info("Error on server #{server}")
-              ::ThinkingSphinx.debug(e.backtrace.join("\n"))
+              ::ThinkingSphinx.debug("#{e.message}\n#{e.backtrace.join("\n")}")
             end
           end
         end
@@ -61,7 +61,7 @@ module Sphinx
         servers = if skip_servers.empty?
                     @servers
                   else
-                    @servers.select { |server| !skip_servers.include?(server) }
+                    @servers.reject { |server| skip_servers.include?(server) }
                   end
 
         best_servers = servers.select(&:fine?)


### PR DESCRIPTION
https://jira.railsc.ru/browse/BPC-18844

* "Мягкое" внедрение таймаутов чтения из сокета, если ПЦ подключат, у них будет работать по-старому, например. Пока не укажем таймаут в конфиге, таймаут бесконечен. Это позволит включать новый механизм по-машинам, а не все сразу.
* Рефакторинг логирования ошибок, добавил с какого сервера происходит переключение. Для справки, на каждой машине sphinx-integration пишет в лог log/sphinx.log