### PR TITLE
fix: use nonblock version of Socket connect

### DIFF
--- a/lib/sphinx/integration/searchd/connection.rb
+++ b/lib/sphinx/integration/searchd/connection.rb
@@ -1,7 +1,12 @@
+require 'socket'
+
 module Sphinx
   module Integration
     module Searchd
       class Connection
+        TIMEOUT = 5
+        private_constant :TIMEOUT
+
         def initialize(host, port)
           @host = host
           @port = port
@@ -10,7 +15,7 @@ module Sphinx
         def socket
           return @socket if @socket
 
-          @socket = TCPSocket.new(@host, @port)
+          @socket = ::Socket.tcp(@host, @port, connect_timeout: TIMEOUT)
           check_version
           @socket.send [1].pack('N'), 0
           core_header = [::Riddle::Client::Commands[:persist], 0, 4].pack("nnN")


### PR DESCRIPTION
https://jira.railsc.ru/browse/BPC-19478

Если указать connection_timeout, то будет использоваться неблокирующий I/O с навешанным таймаутом подключения
https://github.com/ruby/ruby/blob/bbda1a027475bf7ce5e1a9583a7b55d0be71c8fe/ext/socket/lib/socket.rb#L54

Дока
https://ruby-doc.org/stdlib-2.2.7/libdoc/socket/rdoc/Socket.html#method-c-tcp