### PR TITLE
fix: send TRUNCATE RTINDEX to privileged port

### DIFF
--- a/lib/sphinx/integration/statements/distributed.rb
+++ b/lib/sphinx/integration/statements/distributed.rb
@@ -2,6 +2,9 @@ module Sphinx
   module Integration
     module Statements
       class Distributed
+        MATCHING_STMT_RE = /\@([^ ]+) ([^@]+)/.freeze
+        private_constant :MATCHING_STMT_RE
+
         delegate :read, :write, to: '::ThinkingSphinx::Configuration.instance.mysql_client'
 
         def initialize(index)
@@ -75,6 +78,11 @@ module Sphinx
           end
         end
 
+        # Public: отправит запрос в привилегированный порт
+        def write_to_vip_port(query)
+          ::ThinkingSphinx::Configuration.instance.mysql_vip_client.write(query)
+        end
+
         private
 
         def index_name
@@ -94,7 +102,7 @@ module Sphinx
             when Hash
               matching.map { |field, match| [composite_indexes_map[field] || field, match] }
             when String
-              matching.scan(/\@([^ ]+) ([^@]+)/).map do |field, match|
+              matching.scan(MATCHING_STMT_RE).map do |field, match|
                 field = field.to_sym
                 [composite_indexes_map[field] || field, match.strip]
               end

--- a/lib/sphinx/integration/statements/rt.rb
+++ b/lib/sphinx/integration/statements/rt.rb
@@ -42,8 +42,15 @@ module Sphinx
           yield(index_name, sql) if block_given?
         end
 
+        # Public: очищает real-time индекс
+        # Это привилегированная процедура, и запрос отправляется через vip-порт, что позволяет выполнить запрос
+        # в сфинксе в отдельном воркере вне общего пула потоков. Это даст гарантию того, что индексация завершится
+        # корректно.
+        # https://manual.manticoresearch.com/Connecting_to_the_server/MySQL_protocol#VIP-connection
+        #
+        # Returns nothing
         def truncate
-          write("TRUNCATE RTINDEX #{index_name}")
+          write_to_vip_port("TRUNCATE RTINDEX #{index_name}")
         end
 
         private

--- a/spec/sphinx/integration/extensions/thinking_sphinx/index_spec.rb
+++ b/spec/sphinx/integration/extensions/thinking_sphinx/index_spec.rb
@@ -86,6 +86,9 @@ describe ThinkingSphinx::Index do
     it do
       expect(index.rt_name).to eq 'model_with_disk_rt0'
       expect(::ThinkingSphinx::Configuration.instance.mysql_client).
+        not_to receive(:write).with('TRUNCATE RTINDEX model_with_disk_rt1')
+
+      expect(::ThinkingSphinx::Configuration.instance.mysql_vip_client).
         to receive(:write).with('TRUNCATE RTINDEX model_with_disk_rt1')
 
       index.truncate_prev_rt

--- a/spec/sphinx/integration/helper_spec.rb
+++ b/spec/sphinx/integration/helper_spec.rb
@@ -21,6 +21,8 @@ describe Sphinx::Integration::Helper do
           expect(args.core_name).to eq('model_with_rt_core')
         end
         expect(::ThinkingSphinx::Configuration.instance.mysql_client).
+          not_to receive(:write).with('TRUNCATE RTINDEX model_with_rt_rt0')
+        expect(::ThinkingSphinx::Configuration.instance.mysql_vip_client).
           to receive(:write).with('TRUNCATE RTINDEX model_with_rt_rt0')
         expect(::Sphinx::Integration::ReplayerJob).to receive(:enqueue).with('model_with_rt_core')
         helper.index

--- a/spec/sphinx/integration/statements/rt_spec.rb
+++ b/spec/sphinx/integration/statements/rt_spec.rb
@@ -4,6 +4,7 @@ describe Sphinx::Integration::Statements::Rt do
   subject(:statements) { index.rt }
   let(:index) { ModelWithRt.sphinx_indexes.first }
   let(:client) { ::ThinkingSphinx::Configuration.instance.mysql_client }
+  let(:vip_client) { ::ThinkingSphinx::Configuration.instance.mysql_vip_client }
 
   describe "#replace" do
     context 'when single data' do
@@ -41,7 +42,9 @@ describe Sphinx::Integration::Statements::Rt do
 
   describe "#truncate" do
     it do
-      expect(client).to receive(:write).with("TRUNCATE RTINDEX model_with_rt_rt0")
+      expect(client).not_to receive(:write).with("TRUNCATE RTINDEX model_with_rt_rt0")
+      expect(vip_client).to receive(:write).with("TRUNCATE RTINDEX model_with_rt_rt0")
+
       statements.truncate
     end
   end


### PR DESCRIPTION
https://jira.railsc.ru/browse/BPC-20220

Я кратко объясню:

В общем сфинкс работает по модели thread pool, то есть при старте он создает определенное кол-во тредов обычно равное кол-ву 1.5*ядер CPU, ну что логично вроде. Треды эти конечно же линуксовые, они очень похожи на обычные процессы, но это процессы внутри одного процесса.
Есть еще очередь запросов в сфинкс, все запросы которые летят в сфинкс прежде всего попадают в эту очередь сначала, и любой свободный воркер берет из очереди запрос и начинает работать с ним, то есть становится занятым.
Все запросы летят через стандартный порт mysql - 9301 на проде. Дело в том, что сфинкс под собой держит либу-клиент mysql, чтобы запросы были sql'ными)

Во время индексации происходит очистка реал-тайм индекса и переключение на другой реалтайм индекс. Так вот, запрос на очистку раньше слался через общую очередь запросов, и иногда случается такое, когда очередь переполнена, в таком случае сфинкс просто говорит клиентам(приложению) что мол "не могу принять вас". Обычные запросы в этом случае перенаправляются на другой сервер, а вот такие служебные запросы по очистке просто падают. 

В сфинксе есть отдельный порт - т.н. vip, если к нему подцепиться, то запрос пойдет мимо общей очереди, и сфинкс создаст отдельный тред для запуска этого запроса. Собственно PR об этом)